### PR TITLE
Add SMB and Redis based file access service

### DIFF
--- a/src/main/java/org/example/lemonsmb/config/AsyncConfig.java
+++ b/src/main/java/org/example/lemonsmb/config/AsyncConfig.java
@@ -1,0 +1,23 @@
+package org.example.lemonsmb.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.context.annotation.Bean;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+    @Bean
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(4);
+        executor.setMaxPoolSize(8);
+        executor.setQueueCapacity(100);
+        executor.setThreadNamePrefix("smb-");
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/org/example/lemonsmb/config/SmbProperties.java
+++ b/src/main/java/org/example/lemonsmb/config/SmbProperties.java
@@ -1,0 +1,25 @@
+package org.example.lemonsmb.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "smb")
+public class SmbProperties {
+    private String host;
+    private String username;
+    private String password;
+    private String share;
+
+    public String getHost() { return host; }
+    public void setHost(String host) { this.host = host; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+    public String getShare() { return share; }
+    public void setShare(String share) { this.share = share; }
+}

--- a/src/main/java/org/example/lemonsmb/controller/FileController.java
+++ b/src/main/java/org/example/lemonsmb/controller/FileController.java
@@ -1,0 +1,31 @@
+package org.example.lemonsmb.controller;
+
+import org.example.lemonsmb.service.SmbService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@RestController
+public class FileController {
+
+    @Autowired
+    private SmbService smbService;
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    @GetMapping("/metadata")
+    public String metadata() {
+        return redisTemplate.opsForValue().get("metadata");
+    }
+
+    @GetMapping("/files")
+    public CompletableFuture<List<String>> list(@RequestParam(defaultValue = "") String path) {
+        return smbService.listFiles(path);
+    }
+}

--- a/src/main/java/org/example/lemonsmb/service/MetadataLoader.java
+++ b/src/main/java/org/example/lemonsmb/service/MetadataLoader.java
@@ -1,0 +1,35 @@
+package org.example.lemonsmb.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.data.redis.core.StringRedisTemplate;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+@Component
+public class MetadataLoader {
+
+    @Autowired
+    private StringRedisTemplate redisTemplate;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void loadMetadata() throws IOException {
+        Path path = Path.of("视觉素材库.library/metadata.json");
+        if (Files.exists(path)) {
+            String json = Files.readString(path);
+            redisTemplate.opsForValue().set("metadata", json);
+        }
+        Path mtime = Path.of("视觉素材库.library/mtime.json");
+        if (Files.exists(mtime)) {
+            String json = Files.readString(mtime);
+            redisTemplate.opsForValue().set("mtime", json);
+        }
+    }
+}

--- a/src/main/java/org/example/lemonsmb/service/SmbService.java
+++ b/src/main/java/org/example/lemonsmb/service/SmbService.java
@@ -1,0 +1,46 @@
+package org.example.lemonsmb.service;
+
+import com.hierynomus.msfscc.fileinformation.FileIdBothDirectoryInformation;
+import com.hierynomus.smbj.SMBClient;
+import com.hierynomus.smbj.connection.Connection;
+import com.hierynomus.smbj.session.Session;
+import com.hierynomus.smbj.share.DiskShare;
+import com.hierynomus.smbj.auth.AuthenticationContext;
+import org.example.lemonsmb.config.SmbProperties;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class SmbService {
+
+    @Autowired
+    private SmbProperties properties;
+
+    private DiskShare connectShare() throws IOException {
+        SMBClient client = new SMBClient();
+        Connection connection = client.connect(properties.getHost());
+        AuthenticationContext auth = new AuthenticationContext(
+                properties.getUsername(), properties.getPassword().toCharArray(), null);
+        Session session = connection.authenticate(auth);
+        return (DiskShare) session.connectShare(properties.getShare());
+    }
+
+    @Async
+    public CompletableFuture<List<String>> listFiles(String path) {
+        List<String> result = new ArrayList<>();
+        try (DiskShare share = connectShare()) {
+            for (FileIdBothDirectoryInformation f : share.list(path)) {
+                result.add(f.getFileName());
+            }
+        } catch (IOException e) {
+            result.add("ERROR:" + e.getMessage());
+        }
+        return CompletableFuture.completedFuture(result);
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,3 +12,13 @@ spring:
     mode: HTML5
     prefix: classpath:/templates/
     suffix: .html
+  redis:
+    host: localhost
+    port: 6379
+    database: 0
+
+smb:
+  host: 192.168.3.17
+  username: admin
+  password: admin
+  share: DATA

--- a/src/main/resources/templates/files.html
+++ b/src/main/resources/templates/files.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8" />
+    <title>Files</title>
+</head>
+<body>
+<h1>Files</h1>
+<ul id="fileList"></ul>
+<script>
+    fetch('/files?path=')
+        .then(r => r.json())
+        .then(list => {
+            const ul = document.getElementById('fileList');
+            list.forEach(f => {
+                const li = document.createElement('li');
+                li.textContent = f;
+                ul.appendChild(li);
+            });
+        });
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- configure SMB and Redis properties
- add async task executor
- implement SMB service and metadata loader
- expose controller endpoints for metadata and file list
- add simple Thymeleaf page

## Testing
- `mvn -q test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_685fb510b9e08320ae4dcb55c2b247a7