### PR TITLE
Handle missing metadata

### DIFF
--- a/src/main/java/org/example/lemonsmb/service/SmbService.java
+++ b/src/main/java/org/example/lemonsmb/service/SmbService.java
@@ -11,6 +11,8 @@ import com.hierynomus.smbj.session.Session;
 import com.hierynomus.smbj.share.DiskShare;
 import com.hierynomus.smbj.share.File;
 import org.example.lemonsmb.config.SmbProperties;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
@@ -27,6 +29,9 @@ public class SmbService {
 
     @Autowired
     private SmbProperties properties;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+    private JsonNode metadataCache;
 
     public SmbProperties getProperties() {
         return properties;
@@ -46,14 +51,19 @@ public class SmbService {
      */
     public String readFile(String remotePath) throws IOException {
         try (DiskShare share = connectShare()) {
-            File f = share.openFile(remotePath,
-                    EnumSet.of(AccessMask.GENERIC_READ),
-                    null,
-                    SMB2ShareAccess.ALL,
-                    SMB2CreateDisposition.FILE_OPEN,
-                    null);
-            try (InputStream is = f.getInputStream()) {
-                return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+            try {
+                File f = share.openFile(remotePath,
+                        EnumSet.of(AccessMask.GENERIC_READ),
+                        null,
+                        SMB2ShareAccess.ALL,
+                        SMB2CreateDisposition.FILE_OPEN,
+                        null);
+                try (InputStream is = f.getInputStream()) {
+                    return new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                }
+            } catch (com.hierynomus.mssmb2.SMBApiException e) {
+                // Wrap SMB errors so callers can handle uniformly
+                throw new IOException(e);
             }
         }
     }
@@ -61,24 +71,79 @@ public class SmbService {
     @Async
     public CompletableFuture<List<String>> listFiles(String path, int offset, int limit) {
         List<String> result = new ArrayList<>();
-        String target = properties.getLibraryDir() + "/images";
-        if (path != null && !path.isEmpty()) {
-            target = target + "/" + path;
-        }
-        try (DiskShare share = connectShare()) {
-            int count = 0;
-            for (FileIdBothDirectoryInformation f : share.list(target)) {
-                if (count++ < offset) {
-                    continue;
-                }
-                result.add(f.getFileName());
-                if (result.size() >= limit) {
-                    break;
+        try {
+            if (metadataCache == null) {
+                String meta = readFile(properties.getLibraryDir() + "/metadata.json");
+                metadataCache = mapper.readTree(meta).path("folders");
+            }
+
+            String folderId = null;
+            if (path != null && !path.isEmpty()) {
+                folderId = findFolderId(metadataCache, path.split("/"), 0);
+            }
+
+            String imagesBase = properties.getLibraryDir() + "/images";
+            try (DiskShare share = connectShare()) {
+                int processed = 0;
+                for (FileIdBothDirectoryInformation f : share.list(imagesBase)) {
+                    if (!f.getFileName().endsWith(".info")) {
+                        continue;
+                    }
+                    String imageId = f.getFileName().replace(".info", "");
+                    String metaPath = imagesBase + "/" + f.getFileName() + "/metadata.json";
+                    try (File mf = share.openFile(metaPath,
+                            EnumSet.of(AccessMask.GENERIC_READ),
+                            null,
+                            SMB2ShareAccess.ALL,
+                            SMB2CreateDisposition.FILE_OPEN,
+                            null);
+                         InputStream is = mf.getInputStream()) {
+                        String imgMeta = new String(is.readAllBytes(), StandardCharsets.UTF_8);
+                        JsonNode node = mapper.readTree(imgMeta);
+                        boolean match = folderId == null;
+                        if (folderId != null) {
+                            JsonNode arr = node.path("folders");
+                            if (arr.isArray()) {
+                                for (JsonNode n : arr) {
+                                    if (folderId.equals(n.asText())) {
+                                        match = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                        if (match) {
+                            if (processed++ < offset) {
+                                continue;
+                            }
+                            result.add(imageId + "." + node.path("ext").asText());
+                            if (result.size() >= limit) {
+                                break;
+                            }
+                        }
+                    } catch (IOException | com.hierynomus.mssmb2.SMBApiException e) {
+                        // Skip files without metadata or inaccessible entries
+                    }
                 }
             }
         } catch (IOException e) {
             result.add("ERROR:" + e.getMessage());
         }
         return CompletableFuture.completedFuture(result);
+    }
+
+    private String findFolderId(JsonNode folders, String[] names, int index) {
+        if (folders == null || index >= names.length) {
+            return null;
+        }
+        for (JsonNode folder : folders) {
+            if (names[index].equals(folder.path("name").asText())) {
+                if (index == names.length - 1) {
+                    return folder.path("id").asText();
+                }
+                return findFolderId(folder.path("children"), names, index + 1);
+            }
+        }
+        return null;
     }
 }


### PR DESCRIPTION
## Summary
- prevent SMB exceptions when an image folder lacks `metadata.json`
- open metadata using the same SMB share and skip entries that cannot be read

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_685ff316dfe8832ba7cb1d46408aec11