### PR TITLE
Improve file list response

### DIFF
--- a/src/main/java/org/example/lemonsmb/controller/FileController.java
+++ b/src/main/java/org/example/lemonsmb/controller/FileController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.example.lemonsmb.model.FileEntry;
 import java.util.concurrent.CompletableFuture;
 
 @RestController
@@ -35,7 +36,7 @@ public class FileController {
      * 获取文件列表
      */
     @GetMapping("/files")
-    public CompletableFuture<List<String>> list(
+    public CompletableFuture<List<FileEntry>> list(
             @RequestParam(defaultValue = "") String path,
             @RequestParam(defaultValue = "0") int offset,
             @RequestParam(defaultValue = "20") int limit) {

--- a/src/main/java/org/example/lemonsmb/model/FileEntry.java
+++ b/src/main/java/org/example/lemonsmb/model/FileEntry.java
@@ -1,0 +1,33 @@
+package org.example.lemonsmb.model;
+
+/**
+ * Simple DTO representing an entry returned by the file list API.
+ */
+public class FileEntry {
+    private String id;
+    private String name;
+
+    public FileEntry() {
+    }
+
+    public FileEntry(String id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/src/main/java/org/example/lemonsmb/service/SmbService.java
+++ b/src/main/java/org/example/lemonsmb/service/SmbService.java
@@ -14,6 +14,7 @@ import com.hierynomus.protocol.transport.TransportException;
 import com.hierynomus.smbj.common.SMBRuntimeException;
 import org.example.lemonsmb.config.SmbProperties;
 import org.example.lemonsmb.model.FileInfo;
+import org.example.lemonsmb.model.FileEntry;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -263,8 +264,8 @@ public class SmbService {
     }
 
     @Async
-    public CompletableFuture<List<String>> listFiles(String path, int offset, int limit) {
-        List<String> result = new ArrayList<>();
+    public CompletableFuture<List<FileEntry>> listFiles(String path, int offset, int limit) {
+        List<FileEntry> result = new ArrayList<>();
         try {
             if (metadataCache == null) {
                 String meta = readFile(properties.getLibraryDir() + "/metadata.json");
@@ -312,7 +313,10 @@ public class SmbService {
                             if (processed++ < offset) {
                                 continue;
                             }
-                            result.add(imageId + "." + node.path("ext").asText());
+                            String ext = node.path("ext").asText();
+                            String fileName = node.path("name").asText() + "." + ext;
+                            String id = imageId + "." + ext;
+                            result.add(new FileEntry(id, fileName));
                             if (result.size() >= limit) {
                                 break;
                             }

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -693,9 +693,9 @@
                     if (fileList.length === 0 && this.offset === 0) {
                         this.showEmptyState();
                     } else {
-                        fileList.forEach(fileName => {
-                            this.files.push(fileName);
-                            this.createFileCard(fileName);
+                        fileList.forEach(file => {
+                            this.files.push(file);
+                            this.createFileCard(file);
                         });
                         
                         if (fileList.length < this.limit) {
@@ -717,17 +717,19 @@
                 }
             }
 
-            createFileCard(fileName) {
+            createFileCard(file) {
                 const filesGrid = document.getElementById('filesGrid');
                 const fileCard = document.createElement('div');
                 fileCard.className = 'file-card';
-                
+
+                const fileName = file.name;
+                const fileId = file.id;
                 const fileExtension = this.getFileExtension(fileName);
                 const fileType = this.getFileType(fileExtension);
-                
+
                 fileCard.innerHTML = `
                     <div class="file-preview">
-                        ${this.createFilePreview(fileName, fileType)}
+                        ${this.createFilePreview(fileId, fileName, fileType)}
                     </div>
                     <div class="file-info">
                         <div class="file-name" title="${fileName}">${fileName}</div>
@@ -740,17 +742,17 @@
                 
                 // 添加点击事件
                 fileCard.addEventListener('click', () => {
-                    this.previewFile(fileName, fileType);
+                    this.previewFile(fileId, fileName, fileType);
                 });
                 
                 filesGrid.appendChild(fileCard);
             }
 
-            createFilePreview(fileName, fileType) {
+            createFilePreview(fileId, fileName, fileType) {
                 const ext = this.getFileExtension(fileName);
                 // 对所有可能的图片格式都尝试显示图片
                 if (['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg'].includes(ext)) {
-                    return `<img src="/image?id=${encodeURIComponent(fileName)}&thumbnail=true" 
+                    return `<img src="/image?id=${encodeURIComponent(fileId)}&thumbnail=true" 
                                  alt="${fileName}" 
                                  onload="console.log('图片加载成功:', '${fileName}')"
                                  onerror="console.log('图片加载失败:', '${fileName}', this.src); this.style.display='none'; this.nextElementSibling.style.display='flex'">
@@ -825,17 +827,17 @@
                 };
             }
 
-            previewFile(fileName, fileType) {
+            previewFile(fileId, fileName, fileType) {
                 const ext = this.getFileExtension(fileName);
                 // 对所有图片格式都支持预览
                 if (['jpg', 'jpeg', 'png', 'gif', 'bmp', 'webp', 'svg'].includes(ext)) {
-                    this.showImagePreview(fileName);
+                    this.showImagePreview(fileId, fileName);
                 } else {
                     console.log('预览文件:', fileName, fileType);
                 }
             }
 
-            showImagePreview(fileName) {
+            showImagePreview(fileId, fileName) {
                 // 创建模态框
                 const modal = document.createElement('div');
                 modal.className = 'modal fade';
@@ -847,7 +849,7 @@
                                 <button type="button" class="btn-close" data-bs-dismiss="modal"></button>
                             </div>
                             <div class="modal-body text-center">
-                                <img src="/image?id=${encodeURIComponent(fileName)}&thumbnail=false" 
+                                <img src="/image?id=${encodeURIComponent(fileId)}&thumbnail=false" 
                                      class="img-fluid" alt="${fileName}">
                             </div>
                         </div>


### PR DESCRIPTION
## Summary
- add `FileEntry` model to expose id and name
- update SMB service to return `FileEntry` objects with original file names
- adjust controller to return new model
- update frontend to consume new list format and use ids for image paths

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_6861931a908c832bafe12e09068236e6