### PR TITLE
Update path usage for listing

### DIFF
--- a/src/main/java/org/example/lemonsmb/controller/FileController.java
+++ b/src/main/java/org/example/lemonsmb/controller/FileController.java
@@ -34,6 +34,9 @@ public class FileController {
 
     /**
      * 获取文件列表
+     * <p>
+     * <code>path</code> 参数应为 {@code metadata.json} 中对应目录的 <strong>id</strong>，
+     * 而非层级名称。
      */
     @GetMapping("/files")
     public CompletableFuture<List<FileEntry>> list(

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -487,6 +487,7 @@
         class FileExplorer {
             constructor() {
                 this.currentPath = '';
+                this.currentFolderId = '';
                 this.offset = 0;
                 this.limit = 100;
                 this.loading = false;
@@ -576,20 +577,22 @@
 
             buildFolderTree(folders, container = document.getElementById('folderTree'), basePath = '视觉素材库') {
                 const ul = document.createElement('ul');
-                
+
                 folders.forEach(folder => {
                     const li = document.createElement('li');
                     const folderPath = basePath + '/' + folder.name;
-                    
+
+                    const folderId = folder.id;
+
                     const folderItem = document.createElement('div');
                     folderItem.className = 'folder-item';
                     folderItem.innerHTML = `
                         <i class="fas fa-folder"></i>
                         <span>${folder.name}</span>
                     `;
-                    
+
                     folderItem.addEventListener('click', () => {
-                        this.selectFolder(folderPath, folderItem);
+                        this.selectFolder(folderPath, folderId, folderItem);
                         
                         // 展开子文件夹
                         if (folder.children && folder.children.length > 0) {
@@ -610,7 +613,7 @@
                 container.appendChild(ul);
             }
 
-            selectFolder(path, element) {
+            selectFolder(path, id, element) {
                 // 更新活动状态
                 document.querySelectorAll('.folder-item').forEach(item => {
                     item.classList.remove('active');
@@ -619,6 +622,7 @@
 
                 // 更新当前路径和面包屑
                 this.currentPath = path;
+                this.currentFolderId = id;
                 this.updateBreadcrumb();
                 
                 // 重置并加载文件
@@ -665,6 +669,7 @@
                     loading: this.loading,
                     hasMore: this.hasMore,
                     currentPath: this.currentPath,
+                    currentFolderId: this.currentFolderId,
                     offset: this.offset,
                     limit: this.limit
                 });
@@ -678,7 +683,7 @@
                 this.showLoading();
                 
                 try {
-                    const url = `/files?path=${encodeURIComponent(this.currentPath)}&offset=${this.offset}&limit=${this.limit}`;
+                    const url = `/files?path=${encodeURIComponent(this.currentFolderId)}&offset=${this.offset}&limit=${this.limit}`;
                     console.log('请求URL:', url);
                     
                     const response = await fetch(url);
@@ -910,11 +915,12 @@
                             offset: this.offset,
                             loading: this.loading,
                             hasMore: this.hasMore,
-                            currentPath: this.currentPath
+                            currentPath: this.currentPath,
+                            currentFolderId: this.currentFolderId
                         });
-                        
+
                         // 确保有路径且不在加载中且还有更多数据
-                        if (this.currentPath && !this.loading && this.hasMore) {
+                        if (this.currentFolderId && !this.loading && this.hasMore) {
                             console.log('开始加载更多文件...');
                             this.loadFiles();
                         }
@@ -935,10 +941,11 @@
                             offset: this.offset,
                             loading: this.loading,
                             hasMore: this.hasMore,
-                            currentPath: this.currentPath
+                            currentPath: this.currentPath,
+                            currentFolderId: this.currentFolderId
                         });
-                        
-                        if (this.currentPath && !this.loading && this.hasMore) {
+
+                        if (this.currentFolderId && !this.loading && this.hasMore) {
                             console.log('通过窗口滚动加载更多文件...');
                             this.loadFiles();
                         }


### PR DESCRIPTION
## Summary
- treat `path` as folder ID rather than folder hierarchy
- update doc comment for `/files` endpoint
- log error when listFiles fails instead of adding string
- update front-end to send folder IDs when requesting file lists

## Testing
- `mvn -q -DskipTests package` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_b_68619cfbcd34832b9b312d4452fcae01